### PR TITLE
fix: remove pnpm-workspace.yaml to resolve Dependabot issues

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
-  - '@vercel/speed-insights'
-  - esbuild
-  - msw
-  - sharp


### PR DESCRIPTION
- Remove unnecessary pnpm-workspace.yaml file
- This project is a single package, not a monorepo
- Fixes Dependabot error: 'packages field missing or empty'
- Allows Dependabot to properly update dependencies